### PR TITLE
Feature iframe node parent option

### DIFF
--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -38,6 +38,7 @@ export default class Bridge extends Emitter<Emitting> {
 	constructor(connectToUrl: URL, appInfo?: AppInfo) {
 		super()
 		this._appInfo = appInfo
+		this._iframeParentNode = appInfo?.iframeParentNode || document.body
 		this._url = connectToUrl
 				
 		const urlInfo = {

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -1,6 +1,7 @@
 import { is } from 'typescript-is'
 
 import Emitter from './Emitter.js'
+import type { AppInfo } from "./types"
 
 type ChannelController = {
 	window?: Window | null,
@@ -21,7 +22,8 @@ export type Emitting = {
 
 export default class Bridge extends Emitter<Emitting> {
 	private _url: URL
-	private _appInfo?: object
+	private _appInfo?: AppInfo
+	private _iframeParentNode: Node
 	private _iframeEl?: HTMLIFrameElement | null
 	private _iframe: ChannelController = {}
 	private _popup: ChannelController = {}
@@ -33,15 +35,21 @@ export default class Bridge extends Emitter<Emitting> {
 	}[] = []
 	private _pending: number[] = []
 
-	constructor(connectToUrl: URL, appInfo?: object) {
+	constructor(connectToUrl: URL, appInfo?: AppInfo) {
 		super()
 		this._appInfo = appInfo
 		this._url = connectToUrl
-		this._url.hash = new URLSearchParams({
+				
+		const urlInfo = {
 			origin: window.location.origin,
-			...this._appInfo,
 			session: Math.random().toString().slice(2)
-		}).toString()
+		} as any
+
+		if (appInfo?.name) { urlInfo.name = appInfo.name }
+		if (appInfo?.logo) { urlInfo.logo = appInfo.logo }
+
+		this._url.hash = new URLSearchParams(urlInfo).toString()
+
 		window.addEventListener('message', this.listener)
 		this.openIframe()
 	}
@@ -124,7 +132,7 @@ export default class Bridge extends Emitter<Emitting> {
 		const promise = new Promise((resolve, reject) => this._iframe = { resolve, reject })
 		this._iframe.promise = promise
 		const injectIframe = () => {
-			document.body.appendChild(this._iframeEl as Node)
+			this._iframeParentNode.appendChild(this._iframeEl as Node)
 			this._iframe.window = this._iframeEl?.contentWindow
 		}
 		if (document.readyState === 'complete' || document.readyState === 'interactive') { injectIframe() }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,9 @@ type VerifyParams<T> = T extends (...a: any) => any ? (...a: Parameters<T>) => b
 export type AsVerifier<C> = { [Property in keyof C]: VerifyParams<C[Property]> }
 
 export type AppInfo = {
-	name?: string
-	logo?: string
+    name?: string
+    logo?: string
+    iframeParentNode?: Node
 }
 
 export type ProtocolInfo = {


### PR DESCRIPTION
Let's try this again. Adds option to specify `iframeParentNode` on `appInfo` object, defaults to body.

```js
this._iframeParentNode = appInfo?.iframeParentNode || document.body
```

Reverts the `URLSearchParams` back to explicit 2 potential params.